### PR TITLE
Fix apply_{range, domain} typo

### DIFF
--- a/namedisl/set_like.py
+++ b/namedisl/set_like.py
@@ -471,7 +471,7 @@ class Map(_NamedIslMapLike[isl.Map], _NamedIslUnbasic[isl.Map]):
     def apply_range(self, other: Self) -> Self:
         self_a, other_a = align_for_compostition(self, DimType.out, other, DimType.in_)
         return type(self)(
-            self._obj.apply_range(other_a._obj),
+            self_a._obj.apply_range(other_a._obj),
             Space(constantdict({
                 DimType.param: self_a.space.dimtype_to_names[DimType.param],
                 DimType.in_: self_a.space.dimtype_to_names[DimType.in_],
@@ -481,7 +481,7 @@ class Map(_NamedIslMapLike[isl.Map], _NamedIslUnbasic[isl.Map]):
     def apply_domain(self, other: Self) -> Self:
         self_a, other_a = align_for_compostition(self, DimType.in_, other, DimType.out)
         return type(self)(
-            self._obj.apply_domain(other_a._obj),
+            self_a._obj.apply_domain(other_a._obj),
             Space(constantdict({
                 DimType.param: self_a.space.dimtype_to_names[DimType.param],
                 DimType.in_: other_a.space.dimtype_to_names[DimType.in_],

--- a/namedisl/test/test_set_like.py
+++ b/namedisl/test/test_set_like.py
@@ -506,6 +506,15 @@ def test_map_apply_range_can_equate_renamed_collisions_from_mapping() -> None:
     )
 
 
+def test_map_apply_range_unaligned_interface() -> None:
+    lhs = nisl.make_map("{ [x, y] -> [b = x, a = y] }")
+    rhs = nisl.make_map("{ [a, b] -> [u = a, v = b] }")
+
+    ref = nisl.make_map("{ [x, y] -> [u = y, v = x] }")
+
+    assert ref == lhs.apply_range(rhs)
+
+
 def test_equate_dims_mapping_rejects_unknown_name() -> None:
     map_ = nisl.make_map("{ [x] -> [x_out] }")
 
@@ -536,6 +545,15 @@ def test_map_apply_domain_can_explicitly_rename_and_equate_collision() -> None:
         .dim_min("x_out")
         == nisl.make_pw_aff("{ [(4)] }")
     )
+
+
+def test_map_apply_domain_unaligned_interface() -> None:
+    lhs = nisl.make_map("{ [b, a] -> [u = a, v = b] }")
+    rhs = nisl.make_map("{ [x, y] -> [a = x, b = y] }")
+
+    ref = nisl.make_map("{ [x, y] -> [u = x, v = y] }")
+
+    assert ref == lhs.apply_domain(rhs)
 
 
 def test_duplicate_map_names_are_rejected() -> None:


### PR DESCRIPTION
`apply_{range, domain}` do not use the aligned `self` object to perform composition. This results in incorrect results when composition interface names match but order does not.

Adds fix + test.