### PR TITLE
Fix "unsuitable space for set" error when requesting BasicMap/Map domain

### DIFF
--- a/namedisl/set_like.py
+++ b/namedisl/set_like.py
@@ -370,7 +370,7 @@ class BasicMap(_NamedIslMapLike[isl.BasicMap]):
 
     def domain(self) -> BasicSet:
         return BasicSet(
-            self._obj.domain(), 
+            self._obj.domain(),
             self.space
                 .drop_dim_type(DimType.out)
                 .move_dim_type(DimType.in_, DimType.out)
@@ -459,7 +459,7 @@ class Map(_NamedIslMapLike[isl.Map], _NamedIslUnbasic[isl.Map]):
 
     def domain(self) -> Set:
         return Set(
-            self._obj.domain(), 
+            self._obj.domain(),
             self.space
                 .drop_dim_type(DimType.out)
                 .move_dim_type(DimType.in_, DimType.out)

--- a/namedisl/set_like.py
+++ b/namedisl/set_like.py
@@ -369,7 +369,12 @@ class BasicMap(_NamedIslMapLike[isl.BasicMap]):
     """
 
     def domain(self) -> BasicSet:
-        return BasicSet(self._obj.domain(), self.space.drop_dim_type(DimType.out))
+        return BasicSet(
+            self._obj.domain(), 
+            self.space
+                .drop_dim_type(DimType.out)
+                .move_dim_type(DimType.in_, DimType.out)
+        )
 
     def range(self) -> BasicSet:
         return BasicSet(self._obj.range(), self.space.drop_dim_type(DimType.in_))
@@ -453,7 +458,12 @@ class Map(_NamedIslMapLike[isl.Map], _NamedIslUnbasic[isl.Map]):
         return [BasicMap(bs, self.space) for bs in self._obj.get_basic_maps()]
 
     def domain(self) -> Set:
-        return Set(self._obj.domain(), self.space.drop_dim_type(DimType.out))
+        return Set(
+            self._obj.domain(), 
+            self.space
+                .drop_dim_type(DimType.out)
+                .move_dim_type(DimType.in_, DimType.out)
+        )
 
     def range(self) -> Set:
         return Set(self._obj.range(), self.space.drop_dim_type(DimType.in_))

--- a/namedisl/test/test_set_like.py
+++ b/namedisl/test/test_set_like.py
@@ -644,8 +644,8 @@ def test_basic_map_from_map() -> None:
 
 
 def test_basic_map_domain_produces_suitable_space() -> None:
-     m = nisl.make_basic_map("{ [x] -> [y] : y = x + 1 }")
-     m.domain()
+    m = nisl.make_basic_map("{ [x] -> [y] : y = x + 1 }")
+    m.domain()
 
 
 # }}}

--- a/namedisl/test/test_set_like.py
+++ b/namedisl/test/test_set_like.py
@@ -616,6 +616,11 @@ def test_map_as_pw_multi_aff():
     o2 = nisl.make_pw_multi_aff("{ [i] -> [io = (floor((i)/32)), ii = ((i) mod 32)] }")
     assert o1 == o2
 
+
+def test_map_domain_produces_suitable_space() -> None:
+    m = nisl.make_map("{ [x] -> [y] : y = x + 1 }")
+    m.domain()
+
 # }}}
 
 
@@ -636,6 +641,11 @@ def test_basic_map_from_map() -> None:
 
     print(named_map._obj)
     print(named_map)
+
+
+def test_basic_map_domain_produces_suitable_space() -> None:
+     m = nisl.make_basic_map("{ [x] -> [y] : y = x + 1 }")
+     m.domain()
 
 
 # }}}


### PR DESCRIPTION
`Map.domain` properly drops output dimensions, but constructs a `Set` from a `Space` that has input dimensions. This errors with `ValueError: space not suitable for '<class 'namedisl.set_like.Set'>'`. The same is true for `BasicMap.domain`.

The range counterparts do not have this issue since output and set dimensions are the same as far as `isl.dim_type` is concerned.

Fixes by moving surviving input names to `DimType.out` + adds tests.