### PR TITLE
Fix move_dims bug when moving to parameter space

### DIFF
--- a/namedisl/core.py
+++ b/namedisl/core.py
@@ -805,8 +805,13 @@ class NamedIslObject(Generic[IslObjectT_co]):
                 new_dimtype_to_names[dest_dt].extend(self.space.dimtype_to_names[source_dt][start:start+count])
                 isl_dest_dt = dest_dt.as_isl()
 
-                if isinstance(obj, isl.PwMultiAff):
+                if isinstance(obj, (isl.PwMultiAff, isl.Constraint)):
                     raise NotImplementedError
+
+                if dest_dt == DimType.param:
+                    for offset, name in enumerate(
+                            self.space.dimtype_to_names[source_dt][start:start+count]):
+                        obj = _set_dim_name(obj, source_dt, start+offset, name)
 
                 obj = cast("IslObjectT_co",
                     obj.move_dims(

--- a/namedisl/test/test_namedisl.py
+++ b/namedisl/test/test_namedisl.py
@@ -159,6 +159,20 @@ def test_move_dims_multiple_names_preserves_relative_order() -> None:
     assert moved == to_named(expected)
 
 
+def test_move_dims_to_parameter_restores_underlying_names() -> None:
+    named = nisl.make_set("{ [x, y] : x = 5 and y = 5 }")
+    anonymous = nisl.make_set("{ [x] : 0 <= x < 4 }").add_dims(
+        DimType.out, ("y",)
+    )
+
+    moved = (named | anonymous).move_dims({"y"}, DimType.param)
+
+    expected = nisl.make_set("""
+        [y] -> { [x] : 0 <= x < 4; [x = 5] : y = 5 }
+        """)
+    assert moved.equals(expected)
+
+
 def test_rename_dims_set() -> None:
     named_set = nisl.make_set("[p] -> { [x, y] : x < p and y < p }")
 


### PR DESCRIPTION
ISL objects must have named parameter dimensions. Current namedisl `move_dims` behavior blindly moves requested dimensions into parameter space upon request resulting in an error like `islpy._isl.Error: call to isl_set_set_dim_name failed: spaces don't match in /project/isl/isl_type_check_equal_space_templ.c:21` from islpy.

This PR fixes the bug by explicitly naming dimensions in the underlying ISL object if the destination is `DimType.param`. Also adds a regression test.